### PR TITLE
Update recoder.py - Добавлена кодировка cp437

### DIFF
--- a/rurecoder/cyrillic/recoder.py
+++ b/rurecoder/cyrillic/recoder.py
@@ -17,6 +17,7 @@ class Recoder(BaseRecoder):
         'koi8-u',
         'cp1251',
         'cp1252',
+        'cp437',
         'iso8859-1',
         'iso8859-2',
         'iso8859-5',


### PR DESCRIPTION
![Rurecoder GUI_004](https://github.com/user-attachments/assets/eac4e8c6-e82c-46aa-89ef-4a64f50f271b)
![- : mcedit — Konsole_001](https://github.com/user-attachments/assets/be26ae65-27c2-45a1-82be-6cea97777827)
![Выделение_016](https://github.com/user-attachments/assets/4b4b6385-ae32-4242-9ac1-164dab3736b1)
Здравствуйте.

Спасибо вам за вашу утилитку.

Протестировав ее я обратил внимание, что в ней отсутствует одна из возможных поддерживаемых кодировок - cp437. Я посмотрел где указаны кодировки, добавил, протестировал и все работает.

GUI, если что, мое "самописное" (с помощью нейросетей)

Более подробно - https://www.altlinux.org/Rurecoder

Буду благодарен, если вы добавите эту кодировку в апстрим)